### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FOAM
 
-[http://www.foamdev.com]()
+[http://foamdev.com](http://foamdev.com)
 
 ## Feature Oriented Active Modeller
 
@@ -29,13 +29,13 @@ Regression tests whose output has legitimately changed can be conveniently updat
 ```
 node --harmony tests/server.js
 ```
-and then navigate to [http://localhost:8888/tests/FOAMTests.html]().
+and then navigate to [http://localhost:8888/tests/FOAMTests.html](http://localhost:8888/tests/FOAMTests.html).
 
 Any failed regression test will highlight its results with red borders, and the "Update Master" button will write the test's latest results into the master. This edits `tests/FUNTests.xml`, which you should then check in. **Be careful to make sure the new output of the test is actually valid!**
 
 ### UI Testing
 
-A small subset of tests require human oversight. These can be run using the server (see above) and then navigating to [http://localhost:8888/tests/FOAMTests.html?ui=1]() to see just the UI tests.
+A small subset of tests require human oversight. These can be run using the server (see above) and then navigating to [http://localhost:8888/tests/FOAMTests.html?ui=1](http://localhost:8888/tests/FOAMTests.html?ui=1) to see just the UI tests.
 
 The `?ui=1` parameter shows only tests with the `'ui'` tag.
 


### PR DESCRIPTION
It seems linking has to explicitly declare the URL in brackets for the Markdown on GIthub.
