### PR TITLE
Update GitHub Pages config to use HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 # Site settings
 title: FOAM Framework
 description: "FOAM is a deeply MVC Javascript framework"
-baseurl: "http://foam-framework.github.io/foam"
-url: "http://foam-framework.github.io/foam"
+baseurl: "https://foam-framework.github.io/foam"
+url: "https://foam-framework.github.io/foam"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
The main.css stylesheet doesn't load when the site is viewed on HTTPS, because it is being accessed via an HTTP url. HTTPS Everywhere and other security extensions redirect GitHub Pages websites to their HTTPS version.