### PR TITLE
Allow editing of Date Time in local Timezone

### DIFF
--- a/js/foam/ui/DateTimeFieldView.js
+++ b/js/foam/ui/DateTimeFieldView.js
@@ -52,14 +52,13 @@ CLASS({
   ],
 
   methods: {
-      valueToDom: function(value) {
-          return value ? this.localeAware ? value.getTime() - value.getTimezoneOffset() * 60000 :  value.getTime() : 0;
-      },
-      domToValue: function(dom) {
-          var d = new Date(dom);
-          return this.localeAware ?  d = new Date(d.getTime() + d.getTimezoneOffset() * 60000) : d;
-
-      },
+    valueToDom: function(value) {
+      return value ? this.localeAware ? value.getTime() - value.getTimezoneOffset() * 60000 :  value.getTime() : 0;
+    },
+    domToValue: function(dom) {
+      var d = new Date(dom);
+      return this.localeAware ?  new Date(d.getTime() + d.getTimezoneOffset() * 60000) : d;
+    },
 
     toHTML: function() {
       // TODO: Switch type to just datetime when supported.

--- a/js/foam/ui/DateTimeFieldView.js
+++ b/js/foam/ui/DateTimeFieldView.js
@@ -42,12 +42,24 @@ CLASS({
     },
     {
       name: 'data',
-    }
+    },
+    {
+      model_:  'BooleanProperty',
+      name: 'localeAware',
+      help: 'allow editing of date time in local timezone',
+      defaultValue: false,
+    },
   ],
 
   methods: {
-    valueToDom: function(value) { return value ? value.getTime() : 0; },
-    domToValue: function(dom) { return new Date(dom); },
+      valueToDom: function(value) {
+          return value ? this.localeAware ? value.getTime() - value.getTimezoneOffset() * 60000 :  value.getTime() : 0;
+      },
+      domToValue: function(dom) {
+          var d = new Date(dom);
+          return this.localeAware ?  d = new Date(d.getTime() + d.getTimezoneOffset() * 60000) : d;
+
+      },
 
     toHTML: function() {
       // TODO: Switch type to just datetime when supported.


### PR DESCRIPTION
Setting localeAware=true will adjust the Date.getTime() by the local
timezone offset, allowing editing of the Date Time in the
local (browser) timezone.