### PR TITLE
Add support for an 'optional' entry in ChoiceViews

### DIFF
--- a/js/foam/ui/AbstractChoiceView.js
+++ b/js/foam/ui/AbstractChoiceView.js
@@ -83,7 +83,7 @@ CLASS({
             if ( a.hasOwnProperty(key) )
               out.push([key, a[key]]);
           }
-          return out;
+            return this.addOptional(out);
         }
 
         a = a.clone();
@@ -91,7 +91,7 @@ CLASS({
         for ( var i = 0 ; i < a.length ; i++ )
           if ( ! Array.isArray(a[i]) )
             a[i] = [a[i], a[i]];
-        return a;
+          return this.addOptional(a);
       },
       postSet: function(oldValue, newValue) {
         var value = this.data;
@@ -181,6 +181,20 @@ CLASS({
         if ( nu && this.choices.length )
           console.warn('ChoiceView data set to invalid choice: ', nu);
       }
+    },
+    {
+      documentation: function() {/*When 'true', choice selection is optional. A optional or no-selection entry with text 'optionalText' and value 'optionalValue', will be placed at the top of the 'choices' list.*/},
+      model_: 'BooleanProperty',
+      name: 'optional',
+      defaultValue: false,
+    },
+    {
+      name: 'optionalText',
+      defaultValue: '--',
+    },
+    {
+      name: 'optionalValue',
+      defaultValue: undefined,
     }
   ],
 
@@ -215,6 +229,14 @@ CLASS({
     commit: function() {
       if ( this.useSelection && this.choices[this.index] )
         this.choice = this.choices[this.index];
-    }
+    },
+
+    addOptional: function(a) {
+      if (this.optional &&
+          a[0] && a[0][0] != this.optionalValue) {
+          a.unshift([this.optionalValue, this.optionalText]);
+      }
+      return a;
+    },
   }
 });


### PR DESCRIPTION
An optional ChoiceView does not require a selection, and additionally can be used to 'unset' a property.  When enabled an entry such as '--' is added to the top of the choices list.