### PR TITLE
U2: CSS shorthand. Use this.myCls() in code, $ in templates

### DIFF
--- a/core/TemplateUtil.js
+++ b/core/TemplateUtil.js
@@ -256,21 +256,23 @@ MODEL({
           'return function(' + args.join(',') + '){' + code + '};})()' +
           (model ? '\n\n//# sourceURL=' + model.id.replace(/\./g, '/') + '.' + t.name + '\n' : ''));
     },
-    parseCSS: function(t) {
+    parseCSS: function(t, model) {
       var parser = this.CSSParser_ || ( this.CSSParser_ = X.foam.grammars.CSSDecl.create());
+      parser.model = model;
       return parser.parser.parseString(t).toString();
     },
-    parseU2: function(t) {
+    parseU2: function(t, model) {
       var parser = this.U2Parser_ || ( this.U2Parser_ = X.foam.u2.ElementParser.parser__.create() );
+      parser.modelName_ = cssClassize(model.id);
       return parser.parseString(t.trim()).toString();
     },
     compile: function(t, model) {
       if ( t.name !== 'CSS' ) {
         if ( model.isSubModel(X.lookup('foam.u2.Element')) ) {
-          return eval('(function() { return ' + this.parseU2(t.template) + '; })()');
+          return eval('(function() { return ' + this.parseU2(t.template, model) + '; })()');
         }
         if ( t.template.startsWith('#U2') ) {
-          var code = '(function() { return ' + this.parseU2(t.template.substring(3)) + '; })()';
+          var code = '(function() { return ' + this.parseU2(t.template.substring(3), model) + '; })()';
           return eval(code);
         }
       }
@@ -280,7 +282,7 @@ MODEL({
       // Simple case, just a string literal
       if ( parseResult[0] )
         return ConstantTemplate(t.language === 'css' ?
-            this.parseCSS(t.template) :
+            this.parseCSS(t.template, model) :
             t.template) ;
 
       var code = this.HEADER + parseResult[1] + this.FOOTERS[t.language];

--- a/core/stdlib.js
+++ b/core/stdlib.js
@@ -398,6 +398,11 @@ var camelize = memoize1(function (str) {
 });
 
 
+// Replaces . with -, for eg. foam.u2.md.Input -> foam-u2-md-Input
+var cssClassize = memoize1(function (str) {
+  return str.replace(/\./g, '-');
+});
+
 
 MODEL({
   extendsProto: 'Object',

--- a/js/foam/grammars/CSSDecl.js
+++ b/js/foam/grammars/CSSDecl.js
@@ -124,6 +124,10 @@ CLASS({
               '}'),
         }.addActions({
           rulePrefix: function(parts) {
+            // Look for $ signs, and turn them into the model name.
+            parts = parts.map(function(p) {
+              return p.indexOf('$') >= 0 ? p.replace(/\$/g, css.modelName_) : p;
+            });
             return parts.join(' ');
           },
           block: function(parts) {
@@ -154,6 +158,22 @@ CLASS({
           },
         }), seq('/*', repeat(not('*/', anyChar)), '*/'));
       },
+    },
+    {
+      name: 'model',
+      documentation: 'Optional model which contains this CSS template. Used ' +
+          'to expand $ signs in CSS selectors to the model name.',
+      postSet: function(old, nu) {
+        if (nu) this.modelName_ = nu.CSS_CLASS || cssClassize(nu.id);
+      },
+    },
+    {
+      name: 'modelName_',
+      documentation: 'The converted model name itself.',
+      adapt: function(old, nu) {
+        // Turns 'foo-bar quux' into '.foo-bar.quux'
+        return '.' + nu.split(/ +/).join('.');
+      }
     },
   ],
 });

--- a/js/foam/u2/ElementParser.js
+++ b/js/foam/u2/ElementParser.js
@@ -254,7 +254,12 @@ CLASS({
               if ( this.as ) out('var ', this.as, '=');
               out('(opt_e || this.X.E(', nn, '))');
             } else {
-              if ( this.children.length || this.as ) {
+              // If this tag is in any way interesting, it needs to use .s()
+              if ( this.children.length || this.as || this.classes.length ||
+                  Object.keys(this.attributes).length ||
+                  Object.keys(this.xattributes).length ||
+                  Object.keys(this.style).length ||
+                  Object.keys(this.listeners).length) {
                 out('.s(', nn, ')');
                 if ( this.as ) out('.p(s);var ', this.as, '=s[0];s[0]');
               } else {

--- a/js/foam/u2/ElementParser.js
+++ b/js/foam/u2/ElementParser.js
@@ -128,17 +128,13 @@ CLASS({
 
       if: seq1(1, 'if=', sym('ifExpr')),
 
-        ifExpr: alt(
-          seq1(1, '"', sym('value'), '"'),
-          sym('braces')),
-      
+      ifExpr: alt(sym('braces'), sym('value')),
+
       attribute: seq(sym('label'), optional(seq1(1, '=', sym('valueOrLiteral')))),
 
       xattribute: seq('x:', sym('label'), optional(seq1(1, '=', sym('valueOrLiteral')))),
 
-      valueOrLiteral: alt(
-        str(seq('"', sym('value'), '"')),
-        sym('braces')),
+      valueOrLiteral: alt(sym('braces'), sym('value')),
 
       class: seq1(1, 'class=', alt(sym('classList'), sym('classValue'))),
 
@@ -177,7 +173,7 @@ CLASS({
 
       value: str(alt(
         plus(alt(range('a','z'), range('A', 'Z'), range('0', '9'))),
-        seq1(1, '"', repeat(notChar('"')), '"')
+        seq('"', str(repeat(notChar('"'))), '"')
       )),
 
       whitespace: repeat0(alt(' ', '\t', '\r', '\n'))

--- a/js/foam/u2/md/Input.js
+++ b/js/foam/u2/md/Input.js
@@ -28,7 +28,7 @@ CLASS({
       attribute: true,
       defaultValue: true
     },
-    ['showLabel', true],
+    'prop',
     {
       name: 'label',
       attribute: true,
@@ -46,18 +46,18 @@ CLASS({
     function init() {
       this.SUPER();
       var self = this;
-      this.cls('foam-u2-md-Input');
+      this.cls(this.myCls());
       if (this.showLabel) {
         this.start('label')
-            .cls2('foam-u2-md-Input-label')
+            .cls2(this.myCls('label'))
             .cls2(function() {
               return (typeof self.data !== 'undefined' && self.data !== '') ||
-                  self.focused ? 'foam-u2-md-Input-label-offset' : '';
+                  self.focused ? self.myCls('label-offset') : '';
             }.on$(this.X, this.data$, this.focused$))
             .add(this.label$)
             .end();
       } else {
-        this.cls2('foam-u2-md-Input-no-label');
+        this.cls2(this.myCls('no-label'));
       }
 
       var input = this.start('input')
@@ -75,14 +75,14 @@ CLASS({
 
   templates: [
     function CSS() {/*
-      .foam-u2-md-Input {
+      $ {
         align-items: center;
         display: flex;
         margin: 8px;
         padding: 32px 8px 8px 8px;
         position: relative;
       }
-      .foam-u2-md-Input-label {
+      $-label {
         color: #999;
         flex-grow: 1;
         font-size: 14px;
@@ -92,11 +92,11 @@ CLASS({
         transition: font-size 0.5s, top 0.5s;
         z-index: 0;
       }
-      .foam-u2-md-Input-label-offset {
+      $-label-offset {
         font-size: 85%;
         top: 8px;
       }
-      .foam-u2-md-Input input {
+      $ input {
         background: transparent;
         border-bottom: 1px solid #e0e0e0;
         border-left: none;
@@ -111,7 +111,7 @@ CLASS({
         resize: none;
         z-index: 1;
       }
-      .foam-u2-md-Input input:focus {
+      $ input:focus {
         border-bottom: 2px solid #4285f4;
         padding: 0 0 6px 0;
         outline: none;

--- a/js/foam/u2/md/Select.js
+++ b/js/foam/u2/md/Select.js
@@ -27,25 +27,6 @@ CLASS({
     'document',
   ],
 
-  methods: [
-    function init() {
-      this.SUPER();
-
-      this.cls('foam-u2-md-Select')
-          .on('click', this.onClick);
-
-      this.start('label').cls('foam-u2-md-Select-label').add(this.label$).end();
-      this.start().cls('foam-u2-md-Select-value').add(this.text$).end();
-      this.start('svg')
-          .cls('foam-u2-md-Select-down-arrow')
-          .attrs({ width: '12px', height: '12px', viewBox: '0 0 48 48' })
-          .start('g')
-              .start('path').attrs({ d: 'M0 16 l24 24 24 -24 z' }).end()
-          .end()
-      .end();
-    },
-  ],
-
   listeners: [
     {
       name: 'onClick',
@@ -100,6 +81,15 @@ CLASS({
         margin: 8px 8px 2px 16px;
         width: 12px;
       }
+    */},
+    function initE() {/*#U2
+      <div class="$" onClick="onClick">
+        <label class="$-label foo bar">{{this.label$}}</label>
+        <div class="$-value">{{this.text$}}</div>
+        <svg class="$-down-arrow" width="12px" height="12px" viewBox="0 0 48 48">
+          <g><path d="M0 16 l24 24 24 -24 z"></path></g>
+        </svg>
+      </div>
     */},
   ]
 });


### PR DESCRIPTION
For extra bits, use this.myCls('extra') and $-extra. Works in CSS and U2 HTML
templates.

Subclasses don't generally inherit CSS; if you want to modify your parent's CSS
slightly, set the CSS_CLASS constant to your parent's class name, and then you
can use $ in a CSS template to override.

Note that this change also installs CSS for all parent classes at instance
creation time. That might be slightly wasteful but is needed to get subclassing
working nicely.