### PR TITLE
Make the package of an inner model the id of the outer model

### DIFF
--- a/core/mm1Model.js
+++ b/core/mm1Model.js
@@ -699,7 +699,12 @@ v                 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; // we can import the prop
       },
       adapt: function(_, newValue) {
         if ( ! Model ) return newValue;
-        return Array.isArray(newValue) ? JSONUtil.arrayToObjArray(this.X, newValue, Model) : newValue;
+        if ( ! Array.isArray(newValue) ) return newValue;
+        var id = this.id;
+        return JSONUtil.arrayToObjArray(this.X, newValue, Model).map(function(m) {
+          m.package = id;
+          return m;
+        });
       },
       postSet: function(_, models) {
         for ( var i = 0 ; i < models.length ; i++ ) this[models[i].name] = models[i];

--- a/js/foam/u2/md/PopupMenu.js
+++ b/js/foam/u2/md/PopupMenu.js
@@ -251,11 +251,11 @@ CLASS({
       ],
       methods: [
         function initE(opt_x, opt_e) {
-          opt_e.cls('foam-u2-md-PopupMenu-');
+          opt_e.cls(this.myCls());
 
           for (var i = 0; i < this.choices.length; i++) {
             opt_e.start('li')
-                .cls('foam-u2-md-PopupMenu-choice')
+                .cls(this.myCls('choice'))
                 .cls(this.dynamic(function(i) {
                   return this.index === i ? 'selected' : '';
                 }.bind(this, i), this.index$))
@@ -317,9 +317,8 @@ CLASS({
       ],
 
       templates: [
-        // These need to be literal CSS names, because inner models are weird.
         function CSS() {/*
-          .foam-u2-md-PopupMenu- {
+          ^ {
             background: white;
             border: 2px solid grey;
             display: table-footer-group;
@@ -330,7 +329,7 @@ CLASS({
             padding: 0;
             position: absolute;
           }
-          .foam-u2-md-PopupMenu-choice {
+          ^choice {
             align-content: flex-start;
             align-items: flex-end;
             cursor: pointer;
@@ -339,7 +338,7 @@ CLASS({
             overflow: hidden;
             padding: 8px 0px 7px 0px;
           }
-          .foam-u2-md-PopupMenu-choice.selected {
+          ^choice.selected {
             font-weight: bold;
           }
         */}


### PR DESCRIPTION
So inner models have ids like foam.demos.Outer.Inner

That makes the U2 CSS shorthand work nicely for inner models, as well.

Fixes #494.