### PR TITLE
Port TableViews to U2

### DIFF
--- a/js/foam/u2/ScrollView.js
+++ b/js/foam/u2/ScrollView.js
@@ -486,7 +486,7 @@ CLASS({
       }
       this.extraRows = [];
 
-      this.containerE.removeAllChildren();
+      if (this.containerE) this.containerE.removeAllChildren();
 
       this.cache = [];
       this.loadedTop = -1;

--- a/js/foam/u2/ScrollView.js
+++ b/js/foam/u2/ScrollView.js
@@ -56,14 +56,22 @@ CLASS({
 
   properties: [
     {
-      type: 'foam.core.types.DAO',
       name: 'data',
+      postSet: function(old, nu) {
+        this.dao = nu;
+      },
+    },
+    {
+      // TODO(braden): This property only exists because we need to change its
+      // type to DAOProperty.
+      model_: 'foam.core.types.DAOProperty',
+      name: 'dao',
       onDAOUpdate: 'onDAOUpdate',
     },
     {
       name: 'model',
       documentation: 'The model for the data. Defaults to the DAO\'s model.',
-      defaultValueFn: function() { return this.data.model; }
+      defaultValueFn: function() { return this.dao.model; }
     },
     {
       name: 'runway',
@@ -127,7 +135,7 @@ CLASS({
         }
 
         if ( this.rowHeight < 0 ) {
-          this.rowHeight = viewFactory({ model: this.data.model, data: this.data.model.create(null, this.Y) }, this.Y).preferredHeight;
+          this.rowHeight = viewFactory({ model: this.dao.model, data: this.dao.model.create(null, this.Y) }, this.Y).preferredHeight;
         }
       }
     },
@@ -241,7 +249,7 @@ CLASS({
         this.busyComplete_ = this.spinnerBusyStatus.start();
         oldComplete && oldComplete();
 
-        this.data.select(COUNT())(function(c) {
+        this.dao.select(COUNT())(function(c) {
           this.count = c.count;
 
           // That will have updated the height of the inner view.
@@ -316,7 +324,7 @@ CLASS({
           // Something to load.
           var self = this;
           var updateNumber = ++this.daoUpdateNumber;
-          this.data.skip(toLoadTop).limit(toLoadBottom - toLoadTop + 1).select()(function(a) {
+          this.dao.skip(toLoadTop).limit(toLoadBottom - toLoadTop + 1).select()(function(a) {
             if ( updateNumber !== self.daoUpdateNumber ) return;
             if ( ! a || ! a.length ) return;
 
@@ -331,7 +339,7 @@ CLASS({
                 o = a[i].clone();
                 o.addListener(function(x) {
                   // TODO(kgr): remove the deepClone when the DAO does this itself.
-                  this.data.put(x.deepClone());
+                  this.dao.put(x.deepClone());
                 }.bind(self, o));
               }
               self.cache[toLoadTop + i] = o;

--- a/js/foam/u2/ScrollView.js
+++ b/js/foam/u2/ScrollView.js
@@ -477,16 +477,16 @@ CLASS({
     function softCleanup() {
       var keys = Object.keys(this.visibleRows);
       for ( var i = 0; i < keys.length; i++ ) {
-        this.visibleRows[keys[i]].unload();
+        this.visibleRows[keys[i]].remove();
       }
       this.visibleRows = {};
 
       for ( i = 0; i < this.extraRows.length; i++ ) {
-        this.extraRows[i].unload();
+        this.extraRows[i].remove();
       }
       this.extraRows = [];
 
-      if (this.containerE) this.containerE.removeAllChildren();
+      //if (this.containerE) { this.containerE.removeAllChildren(); }
 
       this.cache = [];
       this.loadedTop = -1;

--- a/js/foam/u2/TableRowView.js
+++ b/js/foam/u2/TableRowView.js
@@ -19,7 +19,6 @@ CLASS({
   name: 'TableRowView',
   extends: 'foam.u2.View',
   imports: [
-    'dynamic',
     'hardSelection$',
     'tableView',
   ],

--- a/js/foam/u2/TableRowView.js
+++ b/js/foam/u2/TableRowView.js
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CLASS({
+  package: 'foam.u2',
+  name: 'TableRowView',
+  extends: 'foam.u2.View',
+  imports: [
+    'dynamic',
+    'hardSelection$',
+    'tableView',
+  ],
+
+  properties: [
+    'properties',
+    ['nodeName', 'flex-table-row']
+  ],
+
+  methods: [
+    function isPropNumeric(prop) {
+      return IntProperty.isInstance(prop) || FloatProperty.isInstance(prop);
+    },
+    function getBodyCellClasses(prop, i) {
+      var classes = [this.tableView.myCls('cell'), this.tableView.myCls('col-' + i)];
+      if (this.isPropNumeric(prop))
+        classes.push(this.tableView.myCls('numeric'));
+      return classes;
+    },
+    // Override me to add classes to each row.
+    function getBodyRowClasses() {
+      return [];
+    },
+
+    function initE(opt_e) {
+      this.getBodyRowClasses().forEach(function(c) { this.cls(c); }.bind(this));
+
+      this.dynamic(function(props) {
+        this.removeAllChildren();
+        this.add(props.map(this.makeBodyCell.bind(this)));
+      }.bind(this), this.properties$, this.data$);
+
+      this.on('click', this.onClick);
+      this.cls(this.tableView.myCls('row'));
+      this.cls(this.dynamic(function(sel, data) {
+        return sel === data ? this.tableView.myCls('row-selected') : '';
+      }.bind(this), this.hardSelection$, this.data$));
+    },
+
+    function makeBodyCell(prop, i) {
+      var cell = this.E('flex-table-cell');
+      this.getBodyCellClasses(prop, i).forEach(function(c) { cell.cls(c); });
+      cell.add(prop.tableFormatter ?
+          prop.tableFormatter(this.data[prop.name], this.data, this) :
+          this.data[prop.name]);
+      return cell;
+    },
+  ],
+
+  listeners: [
+    function onClick() {
+      this.hardSelection = this.data;
+    },
+  ],
+});

--- a/js/foam/u2/TableView.js
+++ b/js/foam/u2/TableView.js
@@ -26,7 +26,6 @@ CLASS({
 
   imports: [
     'document',
-    'dynamic',
     'hardSelection$',
     'setTimeout',
     'softSelection$',
@@ -68,7 +67,7 @@ CLASS({
     },
     {
       type: 'Array',
-      name: 'selectedProperties_',
+      name: 'columnProperties_',
       documentation: 'An array of Property objects for all selected ' +
           'properties. That is, the current set of columns. Defaults to the ' +
           'model\'s tableProperties if defined, or all non-hidden properties ' +
@@ -135,10 +134,7 @@ CLASS({
     },
     {
       type: 'Array',
-      name: 'colWidths_',
-      lazyFactory: function() {
-        return [];
-      }
+      name: 'colWidths_'
     },
     {
       type: 'Boolean',
@@ -167,9 +163,9 @@ CLASS({
       var cells = this.headRowE.children;
 
       for (var i = 0; i < cells.length; i++) {
-        if (this.selectedProperties_[i].tableWidth) {
+        if (this.columnProperties_[i].tableWidth) {
           cells[i].style({
-            width: this.selectedProperties_[i].tableWidth + 'px',
+            width: this.columnProperties_[i].tableWidth + 'px',
             'flex-grow': null
           });
         } else {
@@ -275,7 +271,7 @@ CLASS({
         // DOM.
         this.setTimeout(this.onResize, 100);
         return this.headRowE;
-      }.bind(this), this.selectedProperties_$, this.sortOrder$));
+      }.bind(this), this.columnProperties_$, this.sortOrder$));
 
       // Attach a dynamic class to the head that reveals the column resizers
       // when one of them is being dragged.
@@ -335,7 +331,7 @@ CLASS({
       name: 'makeRow',
       code: function(map, Y) {
         map = map || {};
-        map.properties$ = this.selectedProperties_$;
+        map.properties$ = this.columnProperties_$;
         return this.rowView(map, Y);
       }
     },

--- a/js/foam/u2/TableView.js
+++ b/js/foam/u2/TableView.js
@@ -193,7 +193,7 @@ CLASS({
     function measureColWidths(cells) {
       for (var i = 0; i < cells.length; i++) {
         if (!this.colWidths_[i])
-          this.colWidths_[i] = this.SimpleValue.create();
+          this.colWidths_[i] = this.makeColWidthValue(i);
         this.colWidths_[i].set(cells[i].id$el.offsetWidth);
       }
     },
@@ -278,7 +278,7 @@ CLASS({
         this.headRowE = this.E('flex-table-row').cls(this.myCls('row')).add(
             props.map(this.makeHeadCell.bind(this)));
         return this.headRowE;
-      }.bind(this), this.selectedProperties_$));
+      }.bind(this), this.selectedProperties_$, this.sortOrder$));
 
       // Attach a dynamic class to the head that reveals the column resizers
       // when one of them is being dragged.
@@ -293,6 +293,8 @@ CLASS({
       // These can get away with not being dynamic, because the whole header
       // will be rebuilt on a column change.
       cell.cls(this.myCls('col-' + i)).cls(this.myCls('cell'));
+      cell.on('click', this.onSortOrder.bind(this, prop));
+
       if (this.isPropNumeric(prop)) cell.cls(this.myCls('numeric'));
       var sorted = this.isSortedByProp(prop);
       if (sorted) cell.cls(this.myCls('sort'));
@@ -306,14 +308,10 @@ CLASS({
       colLabel.end();
 
       cell.add(this.makeResizeHandle(i));
-      var styleE = this.E('style');
+
       if (!this.colWidths_[i])
-        this.colWidths_[i] = this.SimpleValue.create();
-      this.colWidths_[i].addListener(function(obj, prop, old, nu) {
-        styleE.id$el.innerHTML = '#' + this.id + ' .' + this.myCls('col-' + i) +
-            '{ width: ' + nu + 'px; }';
-      }.bind(this));
-      cell.add(styleE);
+        this.colWidths_[i] = this.makeColWidthValue(i);
+
       return cell;
     },
 
@@ -322,6 +320,16 @@ CLASS({
     },
     function isSortedByProp(prop) {
       return this.sortProp === prop;
+    },
+    function makeColWidthValue(i) {
+      var styleE = this.E('style');
+      var value = this.SimpleValue.create();
+      value.addListener(function(obj, prop, old, nu) {
+        styleE.id$el.innerHTML = '#' + this.id + ' .' + this.myCls('col-' + i) +
+            '{ width: ' + nu + 'px; }';
+      }.bind(this));
+      this.headE.add(styleE);
+      return value;
     },
   ],
 

--- a/js/foam/u2/TableView.js
+++ b/js/foam/u2/TableView.js
@@ -1,0 +1,443 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CLASS({
+  package: 'foam.u2',
+  name: 'TableView',
+  extends: 'foam.u2.View',
+  requires: [
+    'SimpleValue',
+    'foam.u2.ScrollView',
+    'foam.u2.TableRowView',
+  ],
+
+  imports: [
+    'document',
+    'dynamic',
+    'hardSelection$',
+    'softSelection$',
+    'window'
+  ],
+
+  exports: [
+    'as tableView',
+  ],
+
+  documentation: 'A view that renders a table. Note that it does not use real HTML <tt>&lt;table&gt;</tt> tags. Features draggable columns and click-to-sort.',
+
+  properties: [
+    ['nodeName', 'flex-table'],
+    ['ascIcon', '&#9650;'],
+    ['descIcon', '&#9660;'],
+    {
+      name: 'data',
+      postSet: function(old, nu) {
+        this.model = this.getModel();
+      },
+    },
+    {
+      name: 'model',
+      lazyFactory: function() {
+        return this.getModel();
+      },
+      postSet: function(old, nu) {
+        if (old === nu) return;
+        if (nu && this.allProperties_.length === 0)
+          this.allProperties_ = nu.getRuntimeProperties().filter(
+            function(prop) { return !prop.hidden; });
+      }
+    },
+    {
+      type: 'Array',
+      name: 'allProperties_',
+      documentation: 'All the (non-hidden) properties on the model.',
+    },
+    {
+      type: 'Array',
+      name: 'selectedProperties_',
+      documentation: 'An array of Property objects for all selected ' +
+          'properties. That is, the current set of columns. Defaults to the ' +
+          'model\'s tableProperties if defined, or all non-hidden properties ' +
+          'otherwise.',
+      lazyFactory: function() {
+        if (this.model && this.model.tableProperties &&
+            this.model.tableProperties.length > 0) {
+          return this.model.tableProperties.map(function(name) {
+            return this.model.getProperty(name);
+          }.bind(this));
+        } else {
+          return this.allProperties_;
+        }
+      },
+      postSet: function(old, nu) {
+        this.scrollView.softCleanup();
+        // TODO(braden): Used to be initHTML and updateHead here.
+      },
+    },
+    // TODO(braden): Used to have updateHead() and initHTML in a postSet.
+    ['sortOrder', undefined],
+    ['sortProp', undefined],
+    {
+      type: 'Int',
+      name: 'minColWidth',
+      defaultValue: 50
+      // TODO(braden): Used to have injectColStyles() here.
+    },
+    'hardSelection',
+    'softSelection',
+    'headE',
+    'bodyE',
+    {
+      model_: 'foam.core.types.DAOProperty',
+      name: 'filteredDAO',
+      dynamicValue: [function() {
+        this.data; this.sortOrder;
+      }, function() {
+        return this.data.orderBy(this.sortOrder);
+      }]
+    },
+    {
+      type: 'ViewFactory',
+      name: 'rowView',
+      defaultValue: 'foam.u2.TableRowView',
+      documentation: 'Set this to override the row view. It should be a ' +
+          'subclass of $$DOC{ref:"foam.u2.TableRowView"} unless you ' +
+          'really know what you\'re doing.',
+      adapt: function(old, nu) {
+        return nu ? nu : 'foam.u2.TableRowView';
+      }
+    },
+    {
+      name: 'rowHeight',
+      documentation: 'Set this to override the height of a table row.',
+      defaultValue: 48
+    },
+    {
+      name: 'scrollView',
+      factory: function() {
+        return this.ScrollView.create({
+          data: this.filteredDAO$Proxy,
+          rowHeight: this.rowHeight,
+          rowView: this.makeRow,
+        });
+      }
+    },
+    {
+      type: 'Array',
+      name: 'colWidths_',
+      lazyFactory: function() {
+        return [];
+      }
+      // TODO(braden): Used to have injectColStyles in a postSet.
+    },
+    {
+      type: 'Boolean',
+      name: 'isResizing',
+      defaultValue: false
+    },
+  ],
+
+  methods: [
+    function load() {
+      this.SUPER();
+      this.window.addEventListener('resize', this.onResize);
+      this.onResize();
+    },
+    function unload() {
+      this.SUPER();
+      this.window.removeEventListener('resize', this.onResize);
+    },
+    function getModel() {
+      return this.X.model || (this.data && this.data.model);
+    },
+    // Call this to populate the colWidths_ array with the actual values.
+    function computeColWidths() {
+      if (!this.headE || !this.headRowE) return;
+
+      var cells = this.headRowE.children;
+
+      for (var i = 0; i < cells.length; i++) {
+        if (this.selectedProperties_[i].tableWidth) {
+          cells[i].style({
+            width: this.selectedProperties_[i].tableWidth + 'px',
+            'flex-grow': null
+          });
+        } else {
+          cells[i].style({
+            width: 'initial',
+            'flex-grow': '1'
+          });
+        }
+      }
+      this.measureColWidths(cells);
+      for (var i = 0; i < cells.length; i++) {
+        cells[i].style({
+          width: null,
+          'flex-grow': null
+        });
+      }
+    },
+    function measureColWidths(cells) {
+      for (var i = 0; i < cells.length; i++) {
+        if (!this.colWidths_[i])
+          this.colWidths_[i] = this.SimpleValue.create();
+        this.colWidths_[i].set(cells[i].id$el.offsetWidth);
+      }
+    },
+    function onSortOrder(prop) {
+      this.sortProp = prop;
+      this.sortOrder = this.sortOrder === prop ? DESC(prop) : prop;
+    },
+    // Returns a new resize handler element, with event bindings, that follows
+    // column i.
+    function makeResizeHandle(i) {
+      var handle = this.E('flex-col-resize-handle').cls(this.myCls('resize-handle'));
+      handle.on('click', function(e) { e.stopPropagation(); });
+      handle.on('mousedown', function(e) {
+        var self = this;
+        var startX = e.x;
+        var col1 = handle.id$el.parentElement;
+        var col2 = col1.nextElementSibling;
+        var row = col1.parentElement;
+        var w1 = col1.offsetWidth;
+        var w2 = col2? col2.offsetWidth : 0;
+
+        e.preventDefault();
+        this.isResizing = true;
+
+        function onMouseMove(e) {
+          var delta = e.x - startX;
+          var minWidth = self.minColWidth;
+          var newW1 = w1 + ( col2 ? Math.min(w2, delta) : delta );
+          var newW2 = w2 + Math.min(-delta, w1);
+
+          if (newW1 < minWidth) {
+            newW1 = minWidth;
+            newW2 = w1 + w2 - minWidth;
+          } else if (w2 && newW2 < minWidth) {
+            newW1 = w1 + w2 - minWidth;
+            newW2 = minWidth;
+          }
+
+          self.colWidths_[i].set(newW1);
+          // TODO(braden): Might need to tickle something to get it to update
+          // the column widths.
+          // Original had injectColStyle(i) here.
+          //self.colWidths_ = self.colWidths_;
+          if (w2) {
+            self.colWidths_[i + 1].set(newW2);
+            //self.injectColStyle(i + 1);
+          }
+        }
+
+        var onMouseUp = function(e) {
+          e.preventDefault();
+          self.isResizing = false;
+          self.document.removeEventListener('mousemove', onMouseMove);
+          self.document.removeEventListener('mouseup', onMouseUp);
+        };
+
+        self.document.addEventListener('mousemove', onMouseMove);
+        self.document.addEventListener('mouseup', onMouseUp);
+      }.bind(this));
+
+      return handle;
+    },
+    function initE() {
+      // Need to make sure to bind in the flex-table-view-col-resize class, to
+      // the resize boolean.
+      // Need to add/remove (or show/hide) ascending and descending icons for
+      // each column based on the current sort order property.
+
+      this.cls(this.myCls());
+      this.headE = this.start('flex-table-head').cls(this.myCls('head'));
+      this.headE.end();
+      this.bodyE = this.start('flex-table-body').cls(this.myCls('body'));
+      this.bodyE.end();
+
+      // Populate the header. The whole header is wrapped in a dynamic().
+      // It would be slightly better if only the children were, but dynamically
+      // producing an array of elements is not supported right now.
+      this.headE.add(this.dynamic(function(props) {
+        // TODO(braden): Find a way to remove the old listeners, or confirm that
+        // it's already happening properly.
+        //this.colWidths_.forEach(function(value) { value.removeAllListeners(); });
+        this.headRowE = this.E('flex-table-row').cls(this.myCls('row')).add(
+            props.map(this.makeHeadCell.bind(this)));
+        return this.headRowE;
+      }.bind(this), this.selectedProperties_$));
+
+      // Attach a dynamic class to the head that reveals the column resizers
+      // when one of them is being dragged.
+      this.headE.enableCls(this.myCls('col-resize'), this.isResizing$);
+
+      // Populate the body.
+      this.bodyE.add(this.scrollView);
+    },
+    function makeHeadCell(prop, i) {
+      // Returns an array of Elements, suitable for add().
+      var cell = this.E('flex-table-cell');
+      // These can get away with not being dynamic, because the whole header
+      // will be rebuilt on a column change.
+      cell.cls(this.myCls('col-' + i)).cls(this.myCls('cell'));
+      if (this.isPropNumeric(prop)) cell.cls(this.myCls('numeric'));
+      var sorted = this.isSortedByProp(prop);
+      if (sorted) cell.cls(this.myCls('sort'));
+
+      var colLabel = cell.start('flex-col-label').cls(this.myCls('col-label'))
+          .start('label').add(prop.tableLabel).end();
+      if (sorted) {
+        var icon = this.sortOrder === prop ? this.ascIcon : this.descIcon;
+        colLabel.start('span').cls(this.myCls('sort-indicator')).add(icon).end();
+      }
+      colLabel.end();
+
+      cell.add(this.makeResizeHandle(i));
+      var styleE = this.E('style');
+      if (!this.colWidths_[i])
+        this.colWidths_[i] = this.SimpleValue.create();
+      this.colWidths_[i].addListener(function(obj, prop, old, nu) {
+        styleE.id$el.innerHTML = '#' + this.id + ' .' + this.myCls('col-' + i) +
+            '{ width: ' + nu + 'px; }';
+      }.bind(this));
+      cell.add(styleE);
+      return cell;
+    },
+
+    function isPropNumeric(prop) {
+      return IntProperty.isInstance(prop) || FloatProperty.isInstance(prop);
+    },
+    function isSortedByProp(prop) {
+      return this.sortProp === prop;
+    },
+  ],
+
+  listeners: [
+    {
+      name: 'makeRow',
+      code: function(map, Y) {
+        map = map || {};
+        map.properties = this.allProperties_;
+        return this.rowView(map, Y);
+      }
+    },
+    {
+      name: 'onResize',
+      code: function() {
+        this.computeColWidths();
+      }
+    },
+  ],
+
+  templates: [
+    function CSS() {/*
+      ^col-resize * {
+        cursor: ew-resize !important;
+      }
+
+      ^ {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        flex-shrink: 1;
+        overflow-x: hidden;
+        overflow-y: auto;
+        width: 100%;
+      }
+
+      ^head {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+
+      ^body {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1
+        flex-shrink: 1;
+        overflow-x: hidden;
+        overflow-y: auto;
+        position: relative;
+      }
+
+      ^row {
+        display: flex;
+        flex-shrink: 0;
+        flex-grow: 0;
+      }
+
+      ^col-label {
+        display: flex;
+        flex-shrink: 1;
+        flex-grow: 1;
+      }
+
+      ^cell {
+        align-items: center;
+        display: flex;
+        flex-grow: 0;
+        flex-shrink: 0;
+        position: relative;
+      }
+      ^cell^numeric {
+        justify-content: flex-end;
+      }
+
+      ^cell, ^cell * {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      ^cell img {
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+
+      ^cell ^resize-handle {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0px;
+        width: 3px;
+        height: 100%;
+        z-index: 9;
+        cursor: ew-resize;
+      }
+
+      ^numeric {
+        text-align: right;
+      }
+      ^numeric ^col-label {
+        flex-direction: row-reverse;
+      }
+
+      ^sort {
+        font-weight: bold;
+      }
+
+      ^col-label label {
+        flex-grow: 0;
+      }
+      ^col-label span {
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
+    */},
+  ]
+});

--- a/js/foam/u2/TableView.js
+++ b/js/foam/u2/TableView.js
@@ -28,6 +28,7 @@ CLASS({
     'document',
     'dynamic',
     'hardSelection$',
+    'setTimeout',
     'softSelection$',
     'window'
   ],
@@ -83,18 +84,15 @@ CLASS({
         }
       },
       postSet: function(old, nu) {
-        this.scrollView.softCleanup();
-        // TODO(braden): Used to be initHTML and updateHead here.
+        this.scrollView.invalidate();
       },
     },
-    // TODO(braden): Used to have updateHead() and initHTML in a postSet.
     ['sortOrder', undefined],
     ['sortProp', undefined],
     {
       type: 'Int',
       name: 'minColWidth',
       defaultValue: 50
-      // TODO(braden): Used to have injectColStyles() here.
     },
     'hardSelection',
     'softSelection',
@@ -141,7 +139,6 @@ CLASS({
       lazyFactory: function() {
         return [];
       }
-      // TODO(braden): Used to have injectColStyles in a postSet.
     },
     {
       type: 'Boolean',
@@ -233,13 +230,8 @@ CLASS({
           }
 
           self.colWidths_[i].set(newW1);
-          // TODO(braden): Might need to tickle something to get it to update
-          // the column widths.
-          // Original had injectColStyle(i) here.
-          //self.colWidths_ = self.colWidths_;
           if (w2) {
             self.colWidths_[i + 1].set(newW2);
-            //self.injectColStyle(i + 1);
           }
         }
 
@@ -274,9 +266,14 @@ CLASS({
       this.headE.add(this.dynamic(function(props) {
         // TODO(braden): Find a way to remove the old listeners, or confirm that
         // it's already happening properly.
-        //this.colWidths_.forEach(function(value) { value.removeAllListeners(); });
         this.headRowE = this.E('flex-table-row').cls(this.myCls('row')).add(
             props.map(this.makeHeadCell.bind(this)));
+
+        // TODO(braden): This introduces a visible lag, where it renders and
+        // then updates the sizes immediately after.
+        // Find a better way to run something after this new value lands in the
+        // DOM.
+        this.setTimeout(this.onResize, 100);
         return this.headRowE;
       }.bind(this), this.selectedProperties_$, this.sortOrder$));
 
@@ -338,7 +335,7 @@ CLASS({
       name: 'makeRow',
       code: function(map, Y) {
         map = map || {};
-        map.properties = this.allProperties_;
+        map.properties$ = this.selectedProperties_$;
         return this.rowView(map, Y);
       }
     },

--- a/js/foam/u2/md/EditColumnsView.js
+++ b/js/foam/u2/md/EditColumnsView.js
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CLASS({
+  package: 'foam.u2.md',
+  name: 'EditColumnsView',
+  extends: 'foam.u2.Element',
+
+  requires: [
+    'foam.u2.md.Checkbox',
+  ],
+
+  properties: [
+    {
+      name: 'properties',
+    },
+    {
+      name: 'selectedProperties',
+    },
+  ],
+
+  methods: [
+    function selectedMap() {
+      var selected = {};
+      for (var i = 0; i < this.selectedProperties.length; i++) {
+        selected[this.selectedProperties[i].name] = true;
+      }
+      return selected;
+    },
+    function initE() {
+      var selected = this.selectedMap();
+      for (var i = 0; i < this.properties.length; i++) {
+        var cb = this.Checkbox.create({
+          label: this.properties[i].label,
+          data: selected[this.properties[i].name]
+        });
+        cb.data$.addListener(this.onPropChange.bind(this, this.properties[i]));
+        this.add(cb);
+      }
+    },
+  ],
+
+  listeners: [
+    function onPropChange(prop, _, __, old, nu) {
+      var selected = this.selectedMap();
+      var out = [];
+
+      for (var i = 0; i < this.properties.length; i++) {
+        var p = this.properties[i];
+        // Push under two conditions: selected and not just removed,
+        // or not selected but just added.
+        if ((p === prop && nu) || (selected[p.name] && (p !== prop || nu))) {
+          out.push(p);
+        }
+      }
+
+      this.selectedProperties = out;
+    },
+  ]
+});

--- a/js/foam/u2/md/OverlayDropdown.js
+++ b/js/foam/u2/md/OverlayDropdown.js
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CLASS({
+  package: 'foam.u2.md',
+  name: 'OverlayDropdown',
+  extends: 'foam.u2.Element',
+  requires: [
+  ],
+
+  imports: [
+    'document',
+    'dynamic',
+    'window',
+  ],
+  exports: [
+    'as dropdown',
+  ],
+
+  properties: [
+    {
+      type: 'Float',
+      name: 'height',
+      defaultValue: 0,
+      // TODO(braden): Style should react to this property. Remember to guard
+      // against negative.
+    },
+    {
+      type: 'Boolean',
+      name: 'opened',
+      documentation: 'True when the overlay has been commanded to be open. ' +
+          'It might still be animating; see $$DOC{ref:".animationComplete"}.',
+      defaultValue: false,
+    },
+    {
+      type: 'Boolean',
+      name: 'animationComplete',
+      documentation: 'True when an animation is running. The overlay hasn\'t ' +
+          'really reached the state commanded by $$DOC{ref:".opened"} until ' +
+          'this is true.',
+      defaultValue: true
+    },
+    {
+      name: 'dropdownE_',
+      factory: function() {
+        // This needs to be created early so it's safe to add() things to it.
+        return this.E('dropdown');
+      }
+    },
+    {
+      name: 'addToSelf_',
+      defaultValue: false
+    },
+  ],
+
+  methods: [
+    function add() {
+      if (this.addToSelf_) this.SUPER.apply(this, arguments);
+      else this.dropdownE_.add.apply(this.dropdownE_, arguments);
+      return this;
+    },
+    function open() {
+      if (this.opened) return;
+      this.height = -1;
+      this.opened = true;
+      this.animationComplete = false;
+    },
+    function close() {
+      if (!this.opened) return;
+      this.height = 0;
+      this.opened = false;
+    },
+    function getFullHeight() {
+      if (this.state !== this.LOADED) return;
+
+      var myStyle = this.window.getComputedStyle(this.dropdownE_.id$el);
+
+      var border = 0;
+      ['border-top', 'border-bottom'].forEach(function(name) {
+        var math = myStyle[name].match(/^([0-9]+)px/);
+        if (match) border += parseInt(match[1]);
+      });
+
+      var last = this.dropdownE_.children[this.dropdownE_.children.length - 1];
+      var margin = parseInt(this.window.getComputedStyle(last.id$el)['margin-bottom']);
+      if (Number.isNaN(margin)) margin = 0;
+
+      return Math.min(border + last.offsetTop + last.offsetHeight + margin,
+          this.document.body.clientHeight - this.dropdownE_.id$el.getBoundingClientRect().top);
+    },
+    function initE() {
+      this.addToSelf_ = true;
+      this.cls(this.myCls('container'));
+
+      this.style({
+        display: this.dynamic(function(open) {
+          return open ? 'block' : 'none';
+        }, this.opened$)
+      });
+
+      var overlayStyle = this.dynamic(function(open) {
+        return open ? '0' : 'initial';
+      }, this.opened$);
+      this.start('dropdown-overlay')
+          .cls(this.myCls('overlay'))
+          .style({
+            top: overlayStyle,
+            bottom: overlayStyle,
+            left: overlayStyle,
+            right: overlayStyle
+          })
+          .on('click', this.onCancel)
+          .end();
+
+      this.dropdownE_.cls(this.myCls())
+          .cls(this.dynamic(function(open, complete) {
+            return open && complete ? this.myCls('open') : '';
+          }.bind(this), this.opened$, this.animationComplete$))
+          .style({
+            height: this.dynamic(function(height) {
+              // TODO(braden): Should be able to remove this check; height NaN
+              // shouldn't happen.
+              console.assert(!Number.isNaN(height), 'Height should not be NaN.');
+              return (height < 0 ? this.getFullHeight() : height) + 'px';
+            })
+          })
+          .on('transitionend', this.onTransitionEnd)
+          .on('mouseleave', this.onMouseLeave)
+          .on('click', this.onClick);
+
+      this.add(this.dropdownE_);
+
+      this.addToSelf_ = false;
+    },
+  ],
+
+  templates: [
+    function CSS() {/*
+      ^overlay {
+        position: fixed;
+        z-index: 1009;
+      }
+
+      ^container {
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: 100;
+      }
+
+      ^ {
+        background: white;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.38);
+        display: block;
+        font-size: 13px;
+        font-weight: 400;
+        overflow-x: hidden;
+        overflow-y: hidden;
+        position: absolute;
+        right: 3px;
+        top: 4px;
+        transition: height 0.25s cubic-bezier(0, .3, .8, 1);
+        z-index: 1010;
+      }
+
+      ^open {
+        overflow-y: auto;
+      }
+    */},
+  ],
+
+  listeners: [
+    function onCancel() {
+      this.close();
+    },
+    function onTransitionEnd() {
+      this.animationComplete = true;
+    },
+    function onMouseLeave(e) {
+      console.assert(e.target === this.dropdownE_.id$el,
+          'mouseleave should only fire on this, not on children');
+      this.close();
+    },
+    function onClick(e) {
+      // Prevent clicks inside the dropdown from closing it.
+      // Block them before they reach the overlay.
+      e.stopPropagation();
+    },
+  ]
+});

--- a/js/foam/u2/md/OverlayDropdown.js
+++ b/js/foam/u2/md/OverlayDropdown.js
@@ -18,17 +18,18 @@ CLASS({
   package: 'foam.u2.md',
   name: 'OverlayDropdown',
   extends: 'foam.u2.Element',
-  requires: [
-  ],
 
   imports: [
     'document',
-    'dynamic',
     'window',
   ],
   exports: [
     'as dropdown',
   ],
+
+  documentation: 'A popup overlay that grows from the top-right corner of ' +
+      'its container. Useful for e.g. "..." overflow menus in action bars. ' +
+      'Just $$DOC{ref:".add"} things to this container.',
 
   properties: [
     {

--- a/js/foam/u2/md/TableView.js
+++ b/js/foam/u2/md/TableView.js
@@ -20,6 +20,8 @@ CLASS({
   extends: 'foam.u2.TableView',
   requires: [
     'foam.u2.md.ActionButton',
+    'foam.u2.md.EditColumnsView',
+    'foam.u2.md.OverlayDropdown',
     // TODO(braden): Port Icon to U2.
     'foam.ui.Icon',
   ],
@@ -139,6 +141,7 @@ CLASS({
             var X = this.Y.sub({ data: this });
             return X.E('table-actions').cls(this.myCls('actions')).add(actions);
           }.bind(this), this.hardSelection$))
+          .add(this.editColumnsEnabled ? this.columnSelectionE : null)
           .end();
 
       this.SUPER();

--- a/js/foam/u2/md/TableView.js
+++ b/js/foam/u2/md/TableView.js
@@ -34,6 +34,7 @@ CLASS({
       name: 'ascIcon',
       factory: function() {
         return this.Icon.create({
+          url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAQAAAD8x0bcAAAAOklEQVR4AWMYYaABCAkq+Q+EDYSUzGSYBVKGT8l0BkYgxKnMASgxDagACKDK7LEp84YogSgD8kYIAACj3BCo983dYwAAAABJRU5ErkJggg==',
           ligature: 'keyboard_arrow_up',
           width: 16,
           height: 16,
@@ -45,6 +46,7 @@ CLASS({
       name: 'descIcon',
       factory: function() {
         return this.Icon.create({
+          url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAQAAAD8x0bcAAAAQklEQVR4AWMYDoAFnYcJNBnuMFjDebYMtxk0MBVJMtxg+MxgA1XyBciTBLMxlQElbfAoQShDKMGjDKYErzIgHFEAAGLzEOwIrN0jAAAAAElFTkSuQmCC',
           ligature: 'keyboard_arrow_down',
           width: 16,
           height: 16,

--- a/js/foam/u2/md/TableView.js
+++ b/js/foam/u2/md/TableView.js
@@ -86,7 +86,7 @@ CLASS({
       lazyFactory: function() {
         var editor = this.EditColumnsView.create({
           properties$: this.allProperties_$,
-          selectedProperties$: this.selectedProperties_$,
+          selectedProperties$: this.columnProperties_$,
           model$: this.model$
         });
         return this.OverlayDropdown.create().add(editor);

--- a/js/foam/u2/md/TableView.js
+++ b/js/foam/u2/md/TableView.js
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+CLASS({
+  package: 'foam.u2.md',
+  name: 'TableView',
+  extends: 'foam.u2.TableView',
+  requires: [
+    // TODO(braden): Port Icon to U2.
+    'foam.ui.Icon',
+  ],
+
+  constants: {
+    // Keep the same basic CSS class as my parent, since most of the CSS is
+    // common.
+    CSS_CLASS: 'foam-u2-TableView',
+  },
+
+  properties: [
+    {
+      name: 'ascIcon',
+      factory: function() {
+        return this.Icon.create({
+          ligature: 'keyboard_arrow_up',
+          width: 16,
+          height: 16,
+          fontSize: 16
+        });
+      }
+    },
+    {
+      name: 'descIcon',
+      factory: function() {
+        return this.Icon.create({
+          ligature: 'keyboard_arrow_down',
+          width: 16,
+          height: 16,
+          fontSize: 16
+        });
+      }
+    },
+    {
+      name: 'rowHeight',
+      documentation: 'Override this to set the (fixed!) row height of the table.',
+      defaultValue: 48
+    },
+  ],
+
+  methods: [
+    function initE() {
+      // Add the title bar first.
+      //this.start('
+      this.SUPER();
+      this.cls(this.myCls('md'));
+    },
+  ],
+  templates: [
+    function CSS() {/*
+      ^caption {
+        color: rgba(0, 0, 0, 0.87);
+        display: block;
+        font-size: 20px;
+        font-weight: 500;
+      }
+
+      ^title-bar {
+        align-items: center;
+        display: flex;
+        flex-shrink: 0;
+        height: 64px;
+        justify-content: space-between;
+        position: relative;
+      }
+
+      ^title-bar^selection {
+        background: rgb(232, 240, 253);
+      }
+
+      ^title-bar ^caption {
+        padding-left: 24px;
+      }
+
+      ^title-bar^selection ^caption {
+        color: rgb(72, 131, 239);
+      }
+
+      ^actions {
+        color: rgba(0, 0, 0, 0.54);
+        display: flex;
+        font-size: 24px;
+        padding-right: 14px;
+      }
+
+      ^md {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        font-family: 'Roboto', sans-serif;
+        max-width: 100%;
+        overflow: hidden;
+      }
+
+      ^md ^head {
+        color: rgba(0, 0, 0, 0.54);
+        font-size: 12px;
+        font-weight: 500;
+      }
+
+      ^md ^body {
+        border-top: solid 1px #ddd;
+        color: rgba(0, 0, 0, 0.87);
+        font-size: 13px;
+        font-weight: 400;
+      }
+
+      ^md ^body ^row {
+        border-bottom: solid 1px #ddd;
+        cursor: pointer;
+      }
+
+      ^md ^head ^cell {
+        cursor: pointer;
+        height: 64px;
+      }
+
+      ^md ^head ^cell :not(^resize-handle) {
+        cursor: pointer;
+      }
+
+      ^md ^head ^cell:hover ^resize-handle {
+        background: #f5f5f5;
+      }
+
+      ^md ^head ^cell ^resize-handle:hover,
+      ^md ^col-resize ^resize-handle {
+        background: #eee;
+      }
+
+      ^md ^body ^row:hover,
+      ^md ^body ^row^soft-selected {
+        background: #eee;
+      }
+
+      ^md ^row^row-selected {
+        background: #f5f5f5;
+      }
+
+      ^md ^body ^cell {
+        height: 48px;
+      }
+
+      ^md ^sort {
+        color: rgba(0, 0, 0, 0.87);
+        font-size: 12px;
+        font-weight: 500;
+      }
+      ^md ^sort .material-icons,
+      ^md ^sort .material-icons-extended {
+        color: rgba(0, 0, 0, 0.26);
+        font-size: 16px;
+      }
+
+      ^md ^row {
+        padding-left: 12px;
+        padding-right: 12px;
+      }
+
+      ^md ^cell:first-child {
+        padding-left: 12px;
+      }
+
+      ^md ^cell:last-child,
+      ^md ^cell^numeric:last-child,
+      ^md ^cell^sort:last-child,
+      ^md ^cell^numeric^sort:last-child {
+        margin-right: 0px;
+      }
+
+      ^md ^cell {
+        margin-right: 12px;
+        padding-right:12px;
+      }
+      ^md ^cell^numeric {
+        margin-right: 28px;
+        padding-right:28px;
+      }
+
+      ^md .foam-u2-ScrollView-scroller {
+        overflow-x: hidden;
+      }
+    */},
+  ]
+});


### PR DESCRIPTION
Implements #512 .

This scraps the classic, row-scrolling `TableView`. These new models are based on the old `foam.ui.(md.)FlexTableView`, which use the `ScrollView` for native smooth scrolling, and allow adjusting columns.

Both the inheritance/composition graph and the code is simpler than the previous versions.