### PR TITLE
Remove scrolling in FOAM Example

### DIFF
--- a/js/foam/flow/CodeView.js
+++ b/js/foam/flow/CodeView.js
@@ -93,7 +93,6 @@ CLASS({
     function toInnerHTML() {/*<% if ( this.inner ) { %>{{this.inner()}}<% } else { %>{{this.data.code}}<% } %>*/},
     function CSS() {/*
       code-view {
-        display: block;
         position: relative;
         min-height: 10em;
         max-height: 20em;


### PR DESCRIPTION
Maybe it's just me, but having to scroll through the code is tedious.
This change does this:

<img width="671" alt="screen shot 2016-03-30 at 10 33 50 am" src="https://cloud.githubusercontent.com/assets/1282364/14147906/fcfe1ee6-f662-11e5-963e-9c3ca71582b0.png">


Original:

<img width="669" alt="screen shot 2016-03-30 at 10 33 35 am" src="https://cloud.githubusercontent.com/assets/1282364/14147896/f30b2776-f662-11e5-91f0-f0e74433508e.png">
