### PR TITLE
FObject.diff: Only call compareTo on property values when it's defined

### DIFF
--- a/core/FObject.js
+++ b/core/FObject.js
@@ -463,7 +463,7 @@ var FObject = {
         continue;
       }
 
-      if ( property.f(this).compareTo(property.f(other)) !== 0) {
+      if ( property.compare(this, other) !== 0 ) {
         diff[property.name] = property.f(other);
       }
     }


### PR DESCRIPTION
Wondering if this shouldn't instead be calling `property.compareProperty(this, other)`? I thought this is the kind of thing that method is for.