### PR TITLE
Remove scrolling in FOAM Example

### DIFF
--- a/js/foam/flow/CodeSampleViewOutputView.js
+++ b/js/foam/flow/CodeSampleViewOutputView.js
@@ -37,7 +37,7 @@ CLASS({
     },
     {
       name: 'height',
-      defaultValue: 200
+      defaultValue: 300
     },
     {
       name: 'cssHeight',

--- a/js/foam/flow/CodeView.js
+++ b/js/foam/flow/CodeView.js
@@ -93,7 +93,6 @@ CLASS({
     function toInnerHTML() {/*<% if ( this.inner ) { %>{{this.inner()}}<% } else { %>{{this.data.code}}<% } %>*/},
     function CSS() {/*
       code-view {
-        display: block;
         position: relative;
         min-height: 10em;
         max-height: 20em;

--- a/js/foam/flow/FBEModels_toInnerHTML.ft
+++ b/js/foam/flow/FBEModels_toInnerHTML.ft
@@ -89,7 +89,6 @@ X.arequire('foam.sandbox.Person')(function(Person) {
 });</code>
               </src>
             </code-snippet>
-            <code-snippet ref="Person" title="Person Model" />
           </source>
         </code-sample>
       </aside>

--- a/js/foam/flow/FBEModels_toInnerHTML.ft
+++ b/js/foam/flow/FBEModels_toInnerHTML.ft
@@ -311,12 +311,7 @@ X.arequire('foam.sandbox.Person')(function(Person) {
       name: 'children',
       // Tell FOAM to use a suitable list view -- "foam.ui.DAOListView" -- to
       // for the default view of the "children" property.
-      view: 'foam.ui.DAOListView',
-      // Format table cells that contain children: List first names.
-      tableFormatter: function(children) {
-        if ( ! children ) return '';
-        return children.map(function(c) { return c.firstName; }).join(', ');
-      }
+      view: 'foam.ui.DAOListView'
     }
   ]
 });</code>


### PR DESCRIPTION
Allow display of entire code/example w/o scrolling
Increase display size 

Changed to:
<img width="671" alt="screen shot 2016-03-30 at 10 33 50 am" src="https://cloud.githubusercontent.com/assets/1282364/14158784/c19ac3b0-f697-11e5-8617-91fe982e7598.png">

From:
<img width="669" alt="screen shot 2016-03-30 at 10 33 35 am" src="https://cloud.githubusercontent.com/assets/1282364/14158779/bb41d332-f697-11e5-86d1-9583782255a2.png">
