### PR TITLE
Fix FilteredDAO_'s ability to unlisten().

### DIFF
--- a/core/dao.js
+++ b/core/dao.js
@@ -139,6 +139,17 @@ CLASS({
         return super.listen(sink, options: options2)
       */},
     },
+    {
+      name: 'unlisten',
+      code: function(sink) {
+        return this.SUPER(this.decorateSink_(sink, {query: this.query}));
+      },
+      swiftCode: function() {/*
+        let options = DAOQueryOptions()
+        options.query = self.query
+        return super.unlisten(self.decorateSink_(sink, options: options))
+      */},
+    },
     function toString() {
       return this.delegate + '.where(' + this.query + ')';
     }


### PR DESCRIPTION
FilteredDAO_s decorate a sink before calling listen(sink). When
unlisten(sink) is called, the provided sink doesn't match anything in
the daoListeners_ array since it isn't decorated.

This fix makes FilteredDAO_ decorate the sink before calling
super.unlisten(sink), so that a match will be found and removed
appropriately.