### PR TITLE
Update Swift version to 5.0. Update Swift demo projects

### DIFF
--- a/core/mm3Types.js
+++ b/core/mm3Types.js
@@ -711,7 +711,7 @@ CLASS({
         if let numVal = newValue as? NSNumber { return numVal }
         if let intVal = newValue as? Int64 { return NSNumber(value: intVal) }
         // If it's a string, convert it.
-        if let strVal = newValue as? String, let intVal = Int64(strVal) as Int64! {
+        if let strVal = newValue as? String, let intVal = Int64(strVal) {
           return NSNumber(value: intVal)
         }
         return 0

--- a/js/foam/core/Enum.js
+++ b/js/foam/core/Enum.js
@@ -149,10 +149,8 @@ public class <%= this.name %>: FoamEnum, Hashable, Equatable {
   public var index: Int
   public var value: AnyObject
   public var label: String
-  public var hashValue: Int {
-    get {
-      return self.index
-    }
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(index)
   }
   private init(value: AnyObject, label: String, index: Int) {
     self.value = value

--- a/js/foam/dao/FutureDAO.js
+++ b/js/foam/dao/FutureDAO.js
@@ -152,7 +152,7 @@ CLASS({
         future.get { delegate in
           let delegate = delegate as! AbstractDAO
           delegate.select(sink, options: options).get { data in
-            selectFuture.set(data)
+            _ = selectFuture.set(data)
           }
         }
         return selectFuture

--- a/js/foam/dao/nativesupport/ArrayDAO.js
+++ b/js/foam/dao/nativesupport/ArrayDAO.js
@@ -81,7 +81,7 @@ CLASS({
     {
       name: 'remove',
       swiftCode: function() {/*
-        let index = dao.index(of: obj)
+        let index = dao.firstIndex(of: obj)
         if index != nil {
           dao.remove(at: index!)
           sink.remove(obj)

--- a/js/foam/dao/nativesupport/ArraySink.js
+++ b/js/foam/dao/nativesupport/ArraySink.js
@@ -36,7 +36,7 @@ CLASS({
     {
       name: 'remove',
       swiftCode: function() {/*
-        let index = array.index(of: obj)
+        let index = array.firstIndex(of: obj)
         if index != nil {
           _ = array.remove(at: index!)
         }

--- a/js/foam/dao/nativesupport/IdSelectDAO.js
+++ b/js/foam/dao/nativesupport/IdSelectDAO.js
@@ -47,7 +47,7 @@ CLASS({
         let maybeFinish = {
           if done && numSelected == numFound {
             sink.eof()
-            future.set(sink)
+            _ = future.set(sink)
           }
         }
 

--- a/js/foam/persistence/ObjectReplicator.js
+++ b/js/foam/persistence/ObjectReplicator.js
@@ -138,7 +138,7 @@ CLASS({
       swiftCode: function() {/*
         self.obj?.removeListener(self.objChangedListener_)
         if hasOwnProperty("predicatedDao") {
-          self.predicatedDao.unlisten(self.daoListener)
+          _ = self.predicatedDao.unlisten(self.daoListener)
         }
       */},
     },

--- a/swift/demos/LightsOut/LightsOut/LightsOut.xcodeproj/project.pbxproj
+++ b/swift/demos/LightsOut/LightsOut/LightsOut.xcodeproj/project.pbxproj
@@ -247,18 +247,18 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = FOAM;
 				TargetAttributes = {
 					10D6113F1CB89C890021DEF4 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 10D6113B1CB89C890021DEF4 /* Build configuration list for PBXProject "LightsOut" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -369,6 +369,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -425,6 +426,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -479,7 +481,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = foam.demos.LightsOut;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -491,7 +493,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = foam.demos.LightsOut;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/swift/demos/StandingDeskTimer/XCodeProject/StandingTimer.xcodeproj/project.pbxproj
+++ b/swift/demos/StandingDeskTimer/XCodeProject/StandingTimer.xcodeproj/project.pbxproj
@@ -220,18 +220,18 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = FOAM;
 				TargetAttributes = {
 					10D88BD01CB1757B002E3A51 = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0810;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
 			buildConfigurationList = 10D88BCC1CB1757B002E3A51 /* Build configuration list for PBXProject "StandingTimer" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -325,6 +325,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -381,6 +382,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -435,7 +437,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = foam.demos.StandingTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -447,7 +449,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = foam.demos.StandingTimer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/swift/foam/Async.swift
+++ b/swift/foam/Async.swift
@@ -28,6 +28,7 @@ open class Future {
       waiters.append(callback)
     }
   }
+  @discardableResult
   open func set(_ value: AnyObject?) -> Future {
     self.value = value
     set = true

--- a/swift/foam/FOAMSupport.swift
+++ b/swift/foam/FOAMSupport.swift
@@ -97,7 +97,7 @@ open class FObject: PropertyChangeSupport, NSCoding {
   }
   public init(args: [String:AnyObject?] = [:]) {
     super.init()
-    for key in args.keys {
+    for key in args.keys.sorted() {
       _ = set(key, value: args[key]!)
     }
     _foamInit_()
@@ -107,10 +107,12 @@ open class FObject: PropertyChangeSupport, NSCoding {
     fatalError("Called getModel on FObject directly")
   }
   open func get(_ key: String) -> AnyObject? { return nil }
+  @discardableResult
   open func set(_ key: String, value: AnyObject?) -> FObject { return self }
   open func getProperty(_ key: String) -> Property? { return nil }
   open func getPropertyValue(_ key: String) -> PropertyValue? { return nil }
   open func hasOwnProperty(_ key: String) -> Bool { return false }
+  @discardableResult
   open func clearProperty(_ key: String) -> FObject { return self }
   open func copyFrom(_ data: AnyObject?, deep: Bool = false) {
     if let fobj = data as? FObject {


### PR DESCRIPTION
In this PR:

* Swift code in FOAM source code was updated to work with Swift 5.0 compiler. Both compiler errors AND warnings was fixed;
* Swift Demo projects was updated in Xcode 10.2 (the latest and greatest at the moment).

Swift 5 introduces [ABI Stability](https://swift.org/blog/abi-stability-and-more/) which is not the same as Module Stability, but a big step to that.

![1 - DAO Tests](https://user-images.githubusercontent.com/2045882/56765305-95895100-675b-11e9-8446-0e6120ef9702.png)
![2 - Lights Out](https://user-images.githubusercontent.com/2045882/56765309-98844180-675b-11e9-979e-d7d07c165f71.png)
![3 - Standing Desk](https://user-images.githubusercontent.com/2045882/56765316-9a4e0500-675b-11e9-8f70-54c63ed9e2f9.png)
