### PR TITLE
gh-pages index.html: Link to JProfiler

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@ dao.find(someID);</pre>
         <li><a href="https://github.com/foam-framework/foam/wiki/MBug">Mobile QuickBug (MBug)</a> <a href="https://github.com/foam-framework/foam/tree/master/apps/mbug/">(source)</a></li>
         <li><a href="apps/gmail/main.html">GMail Demo</a> <a href="https://github.com/foam-framework/foam/tree/master/js/com/google/mail">(source)</a></li>
         <li><a href="https://chrome.google.com/webstore/detail/chrome-app-builder/ighkikkfkalojiibipjigpccggljgdff">Chrome App Builder</a></li>
+        <li>Java profiling generously enabled by <a href="https://www.ej-technologies.com/buy/jprofiler/openSource">JProfiler open-source licensing</a></li>
       </ul>
     </p>
   </div>


### PR DESCRIPTION
Link to JProfiler open-source licensing page as partial fulfillment of terms for open-source licenses.

CC @shepheb