### PR TITLE
Update link to JProfiler

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@ dao.find(someID);</pre>
         <li><a href="https://github.com/foam-framework/foam/wiki/MBug">Mobile QuickBug (MBug)</a> <a href="https://github.com/foam-framework/foam/tree/master/apps/mbug/">(source)</a></li>
         <li><a href="apps/gmail/main.html">GMail Demo</a> <a href="https://github.com/foam-framework/foam/tree/master/js/com/google/mail">(source)</a></li>
         <li><a href="https://chrome.google.com/webstore/detail/chrome-app-builder/ighkikkfkalojiibipjigpccggljgdff">Chrome App Builder</a></li>
-        <li>Java profiling generously enabled by <a href="https://www.ej-technologies.com/buy/jprofiler/openSource">JProfiler open-source licensing</a></li>
+        <li>Java profiling generously enabled by <a href="https://www.ej-technologies.com/products/jprofiler/overview.html">JProfiler</a> open-source licensing</li>
       </ul>
     </p>
   </div>


### PR DESCRIPTION
The [open source page](https://www.ej-technologies.com/buy/jprofiler/openSource) specifies that the page should link to https://www.ej-technologies.com/products/jprofiler/overview.html.