### PR TITLE
Removed reference to acalc/calc.js which was deleted in bd6577f

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ server.bat
 *~
 .DS_Store
 *.swp
+**/build-web

--- a/js/foam/apps/calc/WebApp.js
+++ b/js/foam/apps/calc/WebApp.js
@@ -68,6 +68,6 @@ __DATA({
     '../js/foam/ui/Window'
   ],
   extraFiles: [
-    '../apps/acalc/Calc'
+
   ]
 });


### PR DESCRIPTION
Just a small fix so acalc builds correctly in anticipation for some accessibility fixes