### PR TITLE
Added key focus UI and arrow key navigation to acalc

### DIFF
--- a/js/foam/apps/calc/HistoryCitationView.js
+++ b/js/foam/apps/calc/HistoryCitationView.js
@@ -15,7 +15,7 @@ CLASS({
   extends: 'foam.ui.View',
   templates: [
     function toHTML() {/*
-      <div class="history" tabindex="2">{{{this.data.op.label}}}&nbsp;{{this.data.a2}}<% if ( this.data.op.label ) { %><hr aria-label="{{foam.apps.calc.Calc.EQUALS.speechLabel}}" tabindex="2"><% } %></div>
+      <div class="history" tabindex="2" >{{{this.data.op.label}}}&nbsp;{{this.data.a2}}</div><% if ( this.data.op.label ) { %><hr aria-label="{{foam.apps.calc.Calc.EQUALS.speechLabel}}"><% } %>
     */}
   ]
 });

--- a/js/foam/apps/calc/MainButtonsView.js
+++ b/js/foam/apps/calc/MainButtonsView.js
@@ -21,33 +21,40 @@ CLASS({
       <div id="%%id" class="buttons button-row" style="background:#4b4b4b;">
         <div class="button-column" style="flex-grow: 3;-webkit-flex-grow: 3;">
           <div class="button-row">
-            $$7{tabIndex: 101} $$8{tabIndex: 102} $$9{tabIndex: 103}
+            $$7{tabIndex: 101, arrowNav: ['.f1', '[4]',   null, '[8]']}
+            $$8{tabIndex: 102, arrowNav: ['.f1', '[5]',  '[7]', '[9]']}
+            $$9{tabIndex: 103, arrowNav: ['.f1', '[6]',  '[8]', '[all clear]']}
           </div>
           <div class="button-row">
-            $$4{tabIndex: 104}$$5{tabIndex: 105}$$6{tabIndex: 106}
+            $$4{tabIndex: 104, arrowNav: ['[7]', '[1]',   null, '[5]']}
+            $$5{tabIndex: 105, arrowNav: ['[8]', '[2]',  '[4]', '[6]']}
+            $$6{tabIndex: 106, arrowNav: ['[9]', '[3]',  '[5]', '[plus]']}
          </div>
           <div class="button-row">
-            $$1{tabIndex: 107}$$2{tabIndex: 108}$$3{tabIndex: 109}
+            $$1{tabIndex: 107, arrowNav: ['[4]', '[point]',  null,  '[2]']}
+            $$2{tabIndex: 108, arrowNav: ['[5]', '[0]',      '[1]',  '[3]']}
+            $$3{tabIndex: 109, arrowNav: ['[6]', '[equals]', '[2]', '[minus]']}
           </div>
           <div class="button-row">
-            $$point{tabIndex: 111}$$0{tabIndex: 111}$$equals{tabIndex: 112}
+            $$point{tabIndex: 111,  arrowNav: ['[1]', null,  null,     '[0]']}
+            $$0{tabIndex: 111,      arrowNav: ['[2]', null, '[point]', '[equals]']}
+            $$equals{tabIndex: 112, arrowNav: ['[3]', null, '[0]',     '[multiply]']}
           </div>
         </div>
-      <%
-      this.X.registerModel(this.CalcButton.xbind({
-        background: '#777',
-        width:  70,
-        height: 45,
-        font:   '300 26px Roboto'
-      }), 'foam.ui.ActionButton');
-      %>
+        <%
+        this.X.registerModel(this.CalcButton.xbind({
+          background: '#777',
+          width:  70,
+          height: 45,
+          font:   '300 26px Roboto'
+        }), 'foam.ui.ActionButton');
+        %>
         <div class="button-column rhs-ops" style="flex-grow: 1;-webkit-flex-grow: 1;padding-top: 7px; padding-bottom: 10px;">
-          $$ac{tabIndex: 201, font: '300 24px Roboto'
-}
-          $$plus{tabIndex: 202}
-          $$minus{tabIndex: 203}
-          $$div{tabIndex: 204}
-          $$mult{tabIndex: 205}
+          $$ac{tabIndex: 201,    arrowNav: ['.f1',         '[plus]',     '[9]',      '[backspace]'], font: '300 24px Roboto'}
+          $$plus{tabIndex: 202,  arrowNav: ['[all clear]', '[minus]',    '[6]',      '[e]']}
+          $$minus{tabIndex: 203, arrowNav: ['[plus]',      '[divide]',   '[3]',      '[inverse]']}
+          $$div{tabIndex: 204,   arrowNav: ['[minus]',     '[multiply]', '[3]',      '[inverse]']}
+          $$mult{tabIndex: 205,  arrowNav: ['[divide]',     null,        '[equals]', '[negate]']}
         </div>
       </div>
     */}

--- a/js/foam/apps/calc/SecondaryButtonsView.js
+++ b/js/foam/apps/calc/SecondaryButtonsView.js
@@ -29,28 +29,28 @@ CLASS({
           <div id="%%id" class="buttons button-row secondaryButtons">
             <div class="button-column" style="flex-grow: 1;-webkit-flex-grow: 1;">
               <div class="button-row">
-                $$backspace{tabIndex: 311, label: '⌫'}
-                $$round{tabIndex: 312}
-                $$fetch{tabIndex: 313}
-                $$store{tabIndex: 314}
+                $$backspace{tabIndex: 311, arrowNav: ['.f1', '[e]',                   '[all clear]',         '[round]'], label: '⌫'}
+                $$round{tabIndex: 312,     arrowNav: ['.f1', '[natural logarithm]',   '[backspace]',         '[fetch from memory]']}
+                $$fetch{tabIndex: 313,     arrowNav: ['.f1', '[log base 10]',         '[round]',             '[store in memory]']}
+                $$store{tabIndex: 314,     arrowNav: ['.f1', '[e to the power of n]', '[fetch from memory]', '[switch to degrees]']}
               </div>
               <div class="button-row">
-                $$e{tabIndex: 321}
-                $$ln{tabIndex: 322}
-                $$log{tabIndex: 323}
-                $$exp{tabIndex: 324}
+                $$e{tabIndex: 321,   arrowNav: ['[backspace]',         '[inverse]',             '[plus]',              '[natural logarithm]']}
+                $$ln{tabIndex: 322,  arrowNav: ['[round]',             '[y to the power of n]', '[e]',                 '[log base 10]']}
+                $$log{tabIndex: 323, arrowNav: ['[fetch from memory]', '[square root]',         '[natural logarithm]', '[e to the power of n]']}
+                $$exp{tabIndex: 324, arrowNav: ['[store to memory]',   '[the enth root of y]',  '[log base 10]',       '[sine]']}
               </div>
               <div class="button-row">
-                $$inv{tabIndex: 331}
-                $$pow{tabIndex: 332}
-                $$sqroot{tabIndex: 333}
-                $$root{tabIndex: 334}
+                $$inv{tabIndex: 331,    arrowNav: ['[e]',                   '[negate]',      '[divide]',               '[y to the power of n]']}
+                $$pow{tabIndex: 332,    arrowNav: ['[natural logarithm]',   '[percent]',     '[inverse]',              '[square root]']}
+                $$sqroot{tabIndex: 333, arrowNav: ['[log base 10]',         '[x squared]',   '[y to the power of n]',  '[the enth root of y]']}
+                $$root{tabIndex: 334,   arrowNav: ['[e to the power of n]', '[π]',           '[square root]',          '[cosine]']}
               </div>
               <div class="button-row">
-                $$sign{tabIndex: 341}
-                $$percent{tabIndex: 342}
-                $$square{tabIndex: 343}
-                $$pi{tabIndex: 344}
+                $$sign{tabIndex: 341,    arrowNav: ['[inverse]',             null, '[multiply]',  '[percent]']}
+                $$percent{tabIndex: 342, arrowNav: ['[y to the power of n]', null, '[negate]',    '[x squared]']}
+                $$square{tabIndex: 343,  arrowNav: ['[square root]',         null, '[percent]',   '[π]']}
+                $$pi{tabIndex: 344,      arrowNav: ['[the enth root of y]',  null, '[x squared]', '[tangent]']}
               </div>
             </div>
           </div>

--- a/js/foam/apps/calc/TertiaryButtonsView.js
+++ b/js/foam/apps/calc/TertiaryButtonsView.js
@@ -28,16 +28,24 @@ CLASS({
           <div id="%%id" class="buttons button-row tertiaryButtons">
             <div class="button-column" style="flex-grow: 1;-webkit-flex-grow: 1;">
               <div class="button-row">
-                $$deg{tabIndex: 411} $$rad{tabIndex: 412} $$fact{tabIndex: 413}
+                $$deg{tabIndex: 411,  arrowNav: ['.f1', '[sine]',    '[store in memory]',   '[switch to radians]']}
+                $$rad{tabIndex: 412,  arrowNav: ['.f1', '[arcsine]', '[switch to degrees]', '[factorial]']}
+                $$fact{tabIndex: 413, arrowNav: ['.f1', '[modulo]',  '[switch to radians]',  null]}
               </div>
               <div class="button-row">
-                $$sin{tabIndex: 421} $$asin{tabIndex: 422} $$mod{tabIndex: 423}
+                $$sin{tabIndex: 421,  arrowNav: ['[switch to degrees]', '[cosine]',      '[e to the power of n]', '[arcsine]']}
+                $$asin{tabIndex: 422, arrowNav: ['[switch to radians]', '[arccosine]',   '[sine]',                '[modulo]']}
+                $$mod{tabIndex: 423,  arrowNav: ['[factorial]',         '[permutation]', '[arcsine]',              null]}
               </div>
               <div class="button-row">
-                $$cos{tabIndex: 431} $$acos{tabIndex: 432} $$p{tabIndex: 433}
+                $$cos{tabIndex: 431,  arrowNav: ['[sine]',    '[tangent]',     '[divide]',    '[arccosine]']}
+                $$acos{tabIndex: 432, arrowNav: ['[arcsine]', '[arctangent]',  '[cosine]',    '[permutation]']}
+                $$p{tabIndex: 433,    arrowNav: ['[modulo]',  '[combination]', '[arccosine]',  null]}
               </div>
               <div class="button-row">
-                $$tan{tabIndex: 441} $$atan{tabIndex: 442} $$c{tabIndex: 443}
+                $$tan{tabIndex: 441,   arrowNav: ['[cosine]',      null, '[π]',          '[arctangent]']}
+                $$atan{tabIndex: 442,  arrowNav: ['[arccosine]',   null, '[tangent]',    '[combination]']}
+                $$c{tabIndex: 443,     arrowNav: ['[permutation]', null, '[arctangent]',  null]}
               </div>
             </div>
           </div>

--- a/js/foam/graphics/AbstractCViewView.js
+++ b/js/foam/graphics/AbstractCViewView.js
@@ -63,6 +63,7 @@ CLASS({
     'speechLabel',
     'role',
     'tabIndex',
+    'arrowNav',
     {
       type: 'Int',
       name:  'width',
@@ -157,9 +158,18 @@ CLASS({
       var className = this.className ? ' class="' + this.className + '"' : '';
       var title     = this.speechLabel ? ' aria-role="button" aria-label="' + this.speechLabel + '"' : '';
       var tabIndex  = this.tabIndex ? ' tabindex="' + this.tabIndex + '"' : '';
-      var role      = this.role ? ' role="' + this.role + '"' : '';
+      var arrowNav  = ''
 
-      return '<canvas id="' + this.id + '"' + className + title + tabIndex + role + ' width="' + this.canvasWidth() + '" height="' + this.canvasHeight() + '" style="width:' + this.styleWidth() + ';height:' + this.styleHeight() + ';min-width:' + this.styleWidth() + ';min-height:' + this.styleHeight() + '"></canvas>';
+      const toSelector = (s) => (s && s[0] === '[') ? s.replace(/\[([^\[\]]+)\]/,'[aria-label=\'$1\']') : s
+
+      if(this.arrowNav) {
+        arrowNav += ' data-arrow-up="' + toSelector(this.arrowNav[0]) + '"';
+        arrowNav += ' data-arrow-down="' + toSelector(this.arrowNav[1]) + '"';
+        arrowNav += ' data-arrow-left="' + toSelector(this.arrowNav[2]) + '"';
+        arrowNav += ' data-arrow-right="' + toSelector(this.arrowNav[3]) + '"';
+      }
+      var role      = this.role ? ' role="' + this.role + '"' : '';
+      return '<canvas id="' + this.id + '"' + className + title + tabIndex + role + arrowNav + ' width="' + this.canvasWidth() + '" height="' + this.canvasHeight() + '" style="width:' + this.styleWidth() + ';height:' + this.styleHeight() + ';min-width:' + this.styleWidth() + ';min-height:' + this.styleHeight() + '"></canvas>';
     },
 
     initHTML: function() { /* Computes the scaling ratio from the window.devicePixelRatio

--- a/js/foam/graphics/ActionButtonCView.js
+++ b/js/foam/graphics/ActionButtonCView.js
@@ -126,6 +126,7 @@ CLASS({
       defaultValueFn: function() { return this.action.speechLabel; }
     },
     'tabIndex',
+    'arrowNav',
     'role',
     {
       name: 'state_',
@@ -209,7 +210,7 @@ CLASS({
 
       // Pressing space when has focus causes a synthetic press
       this.$.addEventListener('keypress', function(e) {
-        if ( e.charCode == 32 && ! ( e.altKey || e.ctrlKey || e.shiftKey ) ) {
+        if ( ( e.charCode == 32 || e.charCode == '13')&& ! ( e.altKey || e.ctrlKey || e.shiftKey ) ) {
           e.preventDefault();
           e.stopPropagation();
           this.tapClick();

--- a/js/foam/graphics/CView.js
+++ b/js/foam/graphics/CView.js
@@ -200,6 +200,7 @@ CLASS({
         if ( this.tooltip )     params.tooltip     = this.tooltip;
         if ( this.speechLabel ) params.speechLabel = this.speechLabel;
         if ( this.tabIndex )    params.tabIndex    = this.tabIndex;
+        if ( this.arrowNav )    params.arrowNav    = this.arrowNav;
         if ( this.role )        params.role        = this.role;
         if ( this.data$ )       params.data$       = this.data$;
         this.view = this.CViewView.create(params);

--- a/js/foam/ui/animated/Label.js
+++ b/js/foam/ui/animated/Label.js
@@ -59,6 +59,10 @@ CLASS({
       .f1.animated {
         transition: left .2s;
       }
+      .f1:focus {
+        border: 2px solid rgba(52, 153, 128, 0.65);
+        border-radius: 10px;
+      }
       .f2 {
         display: inline;
         float: right;

--- a/js/foam/ui/md/Halo.js
+++ b/js/foam/ui/md/Halo.js
@@ -106,6 +106,8 @@ CLASS({
         this.$.addEventListener('mousedown',   this.onMouseDown);
         this.$.addEventListener('mouseup',     this.onMouseUp);
         this.$.addEventListener('mouseleave',  this.onMouseUp);
+        this.$.addEventListener('focus',       this.focus);
+        this.$.addEventListener('blur',        this.blur);
         this.$.addEventListener('touchstart',  this.onMouseDown);
         this.$.addEventListener('touchend',    this.onMouseUp);
         this.$.addEventListener('touchleave',  this.onMouseUp);
@@ -118,13 +120,10 @@ CLASS({
         return t.clientX >= rect.left && t.clientX <= rect.right &&
           t.clientY >= rect.top && t.clientY <= rect.bottom;
       }
-    }
-  ],
-
-  listeners: [
+    },
     {
-      name: 'onMouseDown',
-      code: function(evt) {
+      name: 'paintHalo',
+      code: function(evt, focus) {
         if ( this.state_ !== 'default' || ! this.isEnabled() ) return;
 
         this.state_ = 'pressing';
@@ -171,8 +170,8 @@ CLASS({
       }
     },
     {
-      name: 'onMouseUp',
-      code: function(evt) {
+      name: 'clearHalo',
+      code: function() {
         // This line shouldn't be necessary but we're getting stray
         // onMouseUp events when the cursor moves over the button.
         if ( this.state_ === 'default' ) return;
@@ -191,6 +190,39 @@ CLASS({
               this.color = this.nextColor_;
             }
           }.bind(this))();
+
+        return;
+      }
+    }
+  ],
+
+  listeners: [
+    {
+      name: 'onMouseDown',
+      code: function(evt) {;
+        this.paintHalo(evt, false);
+      }
+    },
+    {
+      name: 'focus',
+      code: function(evt) {
+        this.isFocused = true;
+        this.paintHalo(evt, true);
+      }
+    },
+    {
+      name: 'onMouseUp',
+      code: function() {
+        // ignore mouse up events if we are focused atm
+        if (this.isFocused) return;
+        this.clearHalo()
+      }
+    },
+    {
+      name: 'blur',
+      code: function() {
+        this.clearHalo()
+        this.isFocused = false;
       }
     }
   ]


### PR DESCRIPTION
This is part of a series of accessibility fixes to acalc, a halo is now displayed when a button has keyboard focus and you can navigate around the application with the arrow keys.

In addition the tab index order was tweeked to make more logical sense (app -> history -> display -> buttons), additional fixes to the tab order which make screen readers function better is also on the way.

The way the arrow key functionality works is by attaching query selectors to data attributes on each key to build a "in html" graph. When a certain element is focused and a arrow key is used the focused elements data attributes are used to find the neighbors of the elements and move focus as needed.
